### PR TITLE
just 1.50.0 

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,3 +11,9 @@ cargo-bundle-licenses \
 
 # build statically linked binary with Rust
 cargo install --no-track --locked --root "$PREFIX" --path .
+
+# generate completion files
+mkdir -p "${PREFIX}/etc/bash_completion.d"
+"$PREFIX/bin/just" --completions bash > "${PREFIX}/etc/bash_completion.d/just" || true
+mkdir -p "${PREFIX}/share/zsh/site-functions"
+"$PREFIX/bin/just" --completions zsh > "${PREFIX}/share/zsh/site-functions/_just" || true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,20 @@
 {% set name = "just" %}
-{% set version = "1.39.0" %}
+{% set version = "1.51.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/casey/just/archive/{{ version }}.tar.gz
-  sha256: 8a900072d7f909bc91030df5896168752bb9108967dbb7149d2cfb11fdeb087a
+  url: https://github.com/casey/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: ed424dcf55ec08e22a0c58f6cfb7333573775d69dac3802bf0c1d96f7557089d
 
 build:
   number: 0
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
@@ -31,7 +32,7 @@ about:
   license_family: CC
   summary: just is a handy way to save and run project-specific commands.
   description: just is a handy way to save and run project-specific commands.
-  doc_url: https://just.systems/
+  doc_url: https://just.systems
   dev_url: https://github.com/casey/just
 
 extra:


### PR DESCRIPTION
just 1.50.0 

**Destination channel:** Defaults

### Links

- [PKG-13958]
- dev_url:        https://github.com/casey/just/tree/1.50.0
- conda_forge:    https://github.com/conda-forge/just-feedstock
- pypi:           https://www.google.com/
- pypi inspector: https://www.google.com/

### Explanation of changes:

- new version number


[PKG-13958]: https://anaconda.atlassian.net/browse/PKG-13958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ